### PR TITLE
Add head metadata for better SEO and sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,36 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Personal website and resume of Drew Hockstein"
+    />
+    <title>Drew Hockstein</title>
+    <link rel="icon" href="/favicon.ico" />
+    <meta property="og:title" content="Drew Hockstein" />
+    <meta
+      property="og:description"
+      content="Personal website and resume of Drew Hockstein"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://drew-hockstein.github.io/" />
+    <meta
+      property="og:image"
+      content="https://drew-hockstein.github.io/og-image.png"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Drew Hockstein" />
+    <meta
+      name="twitter:description"
+      content="Personal website and resume of Drew Hockstein"
+    />
+    <meta
+      name="twitter:image"
+      content="https://drew-hockstein.github.io/og-image.png"
+    />
+  </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>


### PR DESCRIPTION
## Summary
- add `<head>` block with title, meta charset, viewport, description
- include favicon and Open Graph/Twitter metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa51d1aaf4832480739b8d887e30b2