### PR TITLE
refactor: centralize navigation links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Skills from './components/Skills';
 import Projects from './components/Projects';
 import Contact from './components/Contact';
 import WorkExperience from './components/WorkExperience';
+import navLinks from './config/navLinks';
 
 export default function App() {
   return (
@@ -56,36 +57,15 @@ export default function App() {
                 reserved.
               </p>
               <div className="flex space-x-6 mt-4 md:mt-0">
-                <a
-                  href="#about"
-                  className="text-gray-400 hover:text-white text-sm transition-colors"
-                >
-                  About
-                </a>
-                <a
-                  href="#experience"
-                  className="text-gray-400 hover:text-white text-sm transition-colors"
-                >
-                  Experience
-                </a>
-                <a
-                  href="#skills"
-                  className="text-gray-400 hover:text-white text-sm transition-colors"
-                >
-                  Skills
-                </a>
-                <a
-                  href="#projects"
-                  className="text-gray-400 hover:text-white text-sm transition-colors"
-                >
-                  Projects
-                </a>
-                <a
-                  href="#contact"
-                  className="text-gray-400 hover:text-white text-sm transition-colors"
-                >
-                  Contact
-                </a>
+                {navLinks.map(({ id, label }) => (
+                  <a
+                    key={id}
+                    href={`#${id}`}
+                    className="text-gray-400 hover:text-white text-sm transition-colors"
+                  >
+                    {label}
+                  </a>
+                ))}
               </div>
             </div>
           </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import navLinks from '../config/navLinks';
 
 export default function Header() {
   const [scrolled, setScrolled] = useState(false);
@@ -35,18 +36,16 @@ export default function Header() {
         </a>
 
         <nav className="hidden md:flex items-center space-x-1">
-          {['About', 'Experience', 'Skills', 'Projects', 'Contact'].map(
-            (item) => (
-              <a
-                key={item}
-                href={`#${item.toLowerCase()}`}
-                onClick={(e) => handleNavClick(e, item.toLowerCase())}
-                className="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-800 rounded-md transition-colors duration-300"
-              >
-                {item}
-              </a>
-            )
-          )}
+          {navLinks.map(({ id, label }) => (
+            <a
+              key={id}
+              href={`#${id}`}
+              onClick={(e) => handleNavClick(e, id)}
+              className="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-800 rounded-md transition-colors duration-300"
+            >
+              {label}
+            </a>
+          ))}
         </nav>
 
         <button
@@ -95,18 +94,16 @@ export default function Header() {
       >
         <div className="container mx-auto px-4 py-4">
           <div className="flex flex-col space-y-2">
-            {['About', 'Experience', 'Skills', 'Projects', 'Contact'].map(
-              (item) => (
-                <a
-                  key={item}
-                  href={`#${item.toLowerCase()}`}
-                  onClick={(e) => handleNavClick(e, item.toLowerCase())}
-                  className="px-4 py-3 text-gray-300 hover:text-white hover:bg-gray-800 rounded-md transition-colors"
-                >
-                  {item}
-                </a>
-              )
-            )}
+            {navLinks.map(({ id, label }) => (
+              <a
+                key={id}
+                href={`#${id}`}
+                onClick={(e) => handleNavClick(e, id)}
+                className="px-4 py-3 text-gray-300 hover:text-white hover:bg-gray-800 rounded-md transition-colors"
+              >
+                {label}
+              </a>
+            ))}
             <div className="pt-2 mt-2 border-t border-gray-800">
               <a
                 href="/Drew_Hockstein_Resume.pdf"

--- a/src/config/navLinks.js
+++ b/src/config/navLinks.js
@@ -1,0 +1,9 @@
+const navLinks = [
+  { id: 'about', label: 'About' },
+  { id: 'experience', label: 'Experience' },
+  { id: 'skills', label: 'Skills' },
+  { id: 'projects', label: 'Projects' },
+  { id: 'contact', label: 'Contact' },
+];
+
+export default navLinks;


### PR DESCRIPTION
## Summary
- create reusable nav links config
- use shared nav links in header and footer

## Testing
- `npm test` *(fails: missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa65f423648324b223703f1ee8743d