### PR TITLE
Add stable IDs to work experience list

### DIFF
--- a/src/components/WorkExperience.jsx
+++ b/src/components/WorkExperience.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 const experiences = [
   {
+    id: 'software-developer',
     title: 'Software Developer',
     company: 'Lumen Technologies',
     location: 'Remote (Based in Denver, CO)',
@@ -13,6 +14,7 @@ const experiences = [
     ],
   },
   {
+    id: 'analyst-intern',
     title: 'Analyst Intern',
     company: 'Lumen Technologies',
     location: 'Broomfield, CO (Hybrid)',
@@ -25,6 +27,7 @@ const experiences = [
     ],
   },
   {
+    id: 'computer-technician',
     title: 'Computer Technician',
     company: 'TIG',
     location: 'Louisville, CO',
@@ -36,6 +39,7 @@ const experiences = [
     ],
   },
   {
+    id: 'course-assistant',
     title: 'Course Assistant',
     company: 'University of Colorado Boulder',
     location: 'Boulder, CO (Hybrid)',
@@ -64,9 +68,9 @@ export default function WorkExperience() {
           </h2>
         </div>
         <div className="max-w-3xl mx-auto space-y-10">
-          {experiences.map((exp, idx) => (
+          {experiences.map((exp) => (
             <div
-              key={idx}
+              key={exp.id}
               className="bg-white rounded-xl shadow-md p-8 border border-gray-200 hover:border-gray-300 transition-colors"
             >
               <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-2">


### PR DESCRIPTION
## Summary
- assign unique `id` to each work experience item
- use `id` instead of index as key when rendering work experience list

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa65f7c6548324a0c0e0643e2fd6b8